### PR TITLE
feat: cross-platform packaging, CI, install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,28 @@ jobs:
         working-directory: gui
         run: npm run build
 
+  go-build-linux:
+    name: Go Build (linux-amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build CLI (linux-amd64)
+        run: make build-linux-amd64
+
+  go-build-windows:
+    name: Go Build (windows-amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build CLI (windows-amd64)
+        run: make build-windows-amd64
+
   proto-lint:
     name: Proto Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,62 @@ jobs:
             build/watchfired-darwin-${{ matrix.arch }}
             build/watchfire-darwin-${{ matrix.arch }}
 
+  build-go-linux:
+    name: Build Go Linux (${{ matrix.arch }})
+    needs: version
+    if: needs.version.outputs.should_build == 'true'
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+        run: |
+          make build-linux-${{ matrix.arch }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-binaries-linux-${{ matrix.arch }}
+          path: |
+            build/watchfire-linux-${{ matrix.arch }}
+            build/watchfired-linux-${{ matrix.arch }}
+
+  build-go-windows:
+    name: Build Go Windows (${{ matrix.arch }})
+    needs: version
+    if: needs.version.outputs.should_build == 'true'
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+        run: |
+          make build-windows-${{ matrix.arch }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-binaries-windows-${{ matrix.arch }}
+          path: |
+            build/watchfire-windows-${{ matrix.arch }}.exe
+            build/watchfired-windows-${{ matrix.arch }}.exe
+
   build-gui:
     name: Build GUI
     needs: [version, build-go]
@@ -305,7 +361,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: [version, build-go, build-gui]
+    needs: [version, build-go, build-go-linux, build-go-windows, build-gui]
     if: needs.version.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -344,6 +400,14 @@ jobs:
                    artifacts/go-binaries-arm64/watchfire-darwin-arm64 \
                    artifacts/go-binaries-amd64/watchfired-darwin-amd64 \
                    artifacts/go-binaries-amd64/watchfire-darwin-amd64 \
+                   artifacts/go-binaries-linux-amd64/watchfire-linux-amd64 \
+                   artifacts/go-binaries-linux-amd64/watchfired-linux-amd64 \
+                   artifacts/go-binaries-linux-arm64/watchfire-linux-arm64 \
+                   artifacts/go-binaries-linux-arm64/watchfired-linux-arm64 \
+                   artifacts/go-binaries-windows-amd64/watchfire-windows-amd64.exe \
+                   artifacts/go-binaries-windows-amd64/watchfired-windows-amd64.exe \
+                   artifacts/go-binaries-windows-arm64/watchfire-windows-arm64.exe \
+                   artifacts/go-binaries-windows-arm64/watchfired-windows-arm64.exe \
                    artifacts/gui-dmg/*.dmg \
                    artifacts/gui-zip/*.zip \
                    artifacts/gui-latest-mac/latest-mac.yml; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.7.0] Ember
+
+### Added
+
+- **Linux and Windows binaries in GitHub Releases** — release workflow now builds amd64 + arm64 for darwin, linux, and windows (6 platform targets total)
+- **Cross-platform CI** — CI workflow verifies builds on macOS, Linux, and Windows
+- **Install scripts** — `scripts/install.sh` (macOS/Linux) and `scripts/install.ps1` (Windows) for one-line installation from GitHub Releases
+- **README.md** — updated with install instructions for all three platforms
+- **No-CGO tray fallback** — daemon runs headless when built without CGO (enables Linux/Windows cross-compilation)
+
+### Changed
+
 ## [0.6.0] Ember
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,17 @@ build-cli-amd64:
 	@mkdir -p $(BUILD_DIR)
 	GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(CLI_BINARY)-amd64 ./$(CMD_DIR)/watchfire
 
+# Linux builds (cross-compilation, no CGO — tray disabled, daemon runs headless)
+build-linux-amd64:
+	@mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(CLI_BINARY)-linux-amd64 ./$(CMD_DIR)/watchfire
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(DAEMON_BINARY)-linux-amd64 ./$(CMD_DIR)/watchfired
+
+build-linux-arm64:
+	@mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(CLI_BINARY)-linux-arm64 ./$(CMD_DIR)/watchfire
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(DAEMON_BINARY)-linux-arm64 ./$(CMD_DIR)/watchfired
+
 # Windows builds (cross-compilation, no CGO — tray disabled, daemon runs headless)
 build-windows-amd64:
 	@mkdir -p $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AI coding agents work best when they have the right context. Watchfire lets you 
 
 ## Install
 
-### Download (macOS)
+### macOS
 
 <p align="center">
   <a href="https://github.com/watchfire-io/watchfire/releases/latest">
@@ -20,20 +20,35 @@ AI coding agents work best when they have the right context. Watchfire lets you 
   </a>
 </p>
 
-### Homebrew
-
-**Desktop app** (GUI + CLI):
+**Homebrew** (recommended):
 
 ```bash
 brew tap watchfire-io/tap
-brew install --cask watchfire-io/tap/watchfire
+brew install --cask watchfire-io/tap/watchfire   # Desktop app (GUI + CLI)
+brew install watchfire-io/tap/watchfire          # CLI & daemon only
 ```
 
-**CLI & daemon only**:
+**Script:**
 
 ```bash
-brew tap watchfire-io/tap
-brew install watchfire-io/tap/watchfire
+curl -fsSL https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.sh | bash
+```
+
+### Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.sh | bash
+```
+
+Homebrew also works on Linux:
+```bash
+brew tap watchfire-io/tap && brew install watchfire-io/tap/watchfire
+```
+
+### Windows
+
+```powershell
+irm https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.ps1 | iex
 ```
 
 ---

--- a/architecture.md
+++ b/architecture.md
@@ -2171,12 +2171,22 @@ Tap repo: `watchfire/homebrew-tap` (separate repo, auto-updated on release)
 | **System tray** | Supported via systray (requires CGO; headless without CGO) |
 | **Notifications** | Windows toast notifications via `beeep` |
 
+### Install Scripts
+
+| Platform | Command |
+|----------|---------|
+| **macOS / Linux** | `curl -fsSL https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.sh \| bash` |
+| **Windows** | `irm https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.ps1 \| iex` |
+
+Both scripts auto-detect OS/arch, download the latest binaries from GitHub Releases, and install to a standard location (`/usr/local/bin` or `~/.local/bin` on Unix, `%LOCALAPPDATA%\Watchfire` on Windows).
+
 ### Distribution
 
 | Channel | What |
 |---------|------|
-| **GitHub Releases** | DMG (macOS), exe binaries (Windows), tarballs (Linux) |
+| **GitHub Releases** | DMG (macOS), standalone binaries (macOS/Linux/Windows amd64+arm64) |
 | **Homebrew** | CLI + daemon (macOS/Linux) |
+| **Install script** | `install.sh` (macOS/Linux), `install.ps1` (Windows) |
 | **Mac App Store** | Future consideration |
 
 ### Auto-Update

--- a/internal/daemon/tray/icon.go
+++ b/internal/daemon/tray/icon.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package tray
 
 import _ "embed"

--- a/internal/daemon/tray/notify.go
+++ b/internal/daemon/tray/notify.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package tray
 
 import (

--- a/internal/daemon/tray/tray.go
+++ b/internal/daemon/tray/tray.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package tray
 
 import (

--- a/internal/daemon/tray/tray.go
+++ b/internal/daemon/tray/tray.go
@@ -32,8 +32,8 @@ var (
 	portItem *systray.MenuItem
 
 	// Serialized tray update channel (prevents concurrent Cocoa API calls)
-	updateCh chan struct{}  // signal channel
-	updateMu sync.Mutex    // protects latestAgents
+	updateCh     chan struct{} // signal channel
+	updateMu     sync.Mutex    // protects latestAgents
 	latestAgents []AgentInfo
 
 	// Dynamic tray icons

--- a/internal/daemon/tray/tray.go
+++ b/internal/daemon/tray/tray.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/getlantern/systray"
+
 	"github.com/watchfire-io/watchfire/internal/buildinfo"
 )
 

--- a/internal/daemon/tray/tray_nocgo.go
+++ b/internal/daemon/tray/tray_nocgo.go
@@ -1,0 +1,52 @@
+//go:build !cgo
+
+package tray
+
+import (
+	"log"
+	"sync"
+)
+
+var (
+	onStart func()
+	onExit  func()
+	done    = make(chan struct{})
+	mu      sync.Mutex
+	running bool
+)
+
+// Run starts the daemon without a system tray (CGO not available).
+// It calls onStartFn to allow daemon initialization, then blocks until Quit().
+func Run(s DaemonState, onStartFn, onExitFn func()) {
+	onStart = onStartFn
+	onExit = onExitFn
+
+	log.Println("[watchfire] System tray unavailable (built without CGO); daemon running headless")
+
+	mu.Lock()
+	running = true
+	mu.Unlock()
+
+	if onStart != nil {
+		onStart()
+	}
+
+	<-done // Block until Quit()
+}
+
+// Quit signals the daemon to shut down.
+func Quit() {
+	mu.Lock()
+	defer mu.Unlock()
+	if !running {
+		return
+	}
+	running = false
+	if onExit != nil {
+		onExit()
+	}
+	close(done)
+}
+
+// UpdateAgents is a no-op without a tray.
+func UpdateAgents(agents []AgentInfo) {}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,89 @@
+# Watchfire installer for Windows
+# Usage: irm https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.ps1 | iex
+$ErrorActionPreference = "Stop"
+
+$Repo = "watchfire-io/watchfire"
+$InstallDir = if ($env:WATCHFIRE_INSTALL_DIR) { $env:WATCHFIRE_INSTALL_DIR } else { "$env:LOCALAPPDATA\Watchfire" }
+
+function Write-Info($msg)  { Write-Host "  $msg" -ForegroundColor Cyan }
+function Write-Ok($msg)    { Write-Host "  $msg" -ForegroundColor Green }
+function Write-Warn($msg)  { Write-Host "  $msg" -ForegroundColor Yellow }
+
+# Detect architecture
+function Get-Arch {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        "X64"   { return "amd64" }
+        "Arm64" { return "arm64" }
+        default { throw "Unsupported architecture: $arch" }
+    }
+}
+
+# Fetch latest version
+function Get-LatestVersion {
+    $url = "https://api.github.com/repos/$Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $url -Headers @{ "User-Agent" = "watchfire-installer" }
+    return $release.tag_name -replace "^v", ""
+}
+
+Write-Host ""
+Write-Host "  Watchfire Installer" -ForegroundColor Cyan
+Write-Host ""
+
+$Arch = Get-Arch
+$Version = Get-LatestVersion
+
+Write-Info "OS: windows | Arch: $Arch | Version: v$Version"
+Write-Info "Install directory: $InstallDir"
+
+# Create install directory
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+$BaseUrl = "https://github.com/$Repo/releases/download/v$Version"
+$CliName = "watchfire-windows-$Arch.exe"
+$DaemonName = "watchfired-windows-$Arch.exe"
+
+# Download binaries
+Write-Info "Downloading watchfire v$Version..."
+
+$TempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+try {
+    Invoke-WebRequest -Uri "$BaseUrl/$CliName" -OutFile "$TempDir\watchfire.exe" -UseBasicParsing
+    Invoke-WebRequest -Uri "$BaseUrl/$DaemonName" -OutFile "$TempDir\watchfired.exe" -UseBasicParsing
+}
+catch {
+    throw "Download failed: $_"
+}
+
+# Install
+Write-Info "Installing to $InstallDir..."
+Move-Item -Force "$TempDir\watchfire.exe" "$InstallDir\watchfire.exe"
+Move-Item -Force "$TempDir\watchfired.exe" "$InstallDir\watchfired.exe"
+Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
+
+# Verify
+$ver = & "$InstallDir\watchfire.exe" version 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Ok "watchfire v$Version installed successfully!"
+}
+else {
+    throw "Installation failed - binary not executable"
+}
+
+# Add to PATH if not already there
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    Write-Warn "$InstallDir is not in your PATH. Adding it now..."
+    [Environment]::SetEnvironmentVariable("Path", "$InstallDir;$UserPath", "User")
+    $env:Path = "$InstallDir;$env:Path"
+    Write-Ok "Added $InstallDir to user PATH (restart your terminal for full effect)"
+}
+
+Write-Host ""
+Write-Host "  Get started:" -ForegroundColor Green
+Write-Host "    cd your-project"
+Write-Host "    watchfire init"
+Write-Host "    watchfire run"
+Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Watchfire installer for macOS and Linux
+# Usage: curl -fsSL https://raw.githubusercontent.com/watchfire-io/watchfire/main/scripts/install.sh | bash
+set -euo pipefail
+
+REPO="watchfire-io/watchfire"
+INSTALL_DIR="${WATCHFIRE_INSTALL_DIR:-}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { printf "${CYAN}▸${NC} %s\n" "$1"; }
+ok()    { printf "${GREEN}✓${NC} %s\n" "$1"; }
+warn()  { printf "${YELLOW}!${NC} %s\n" "$1"; }
+error() { printf "${RED}✗${NC} %s\n" "$1" >&2; exit 1; }
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) echo "darwin" ;;
+        Linux)  echo "linux" ;;
+        *)      error "Unsupported OS: $(uname -s). Use the PowerShell script for Windows." ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)   echo "amd64" ;;
+        arm64|aarch64)  echo "arm64" ;;
+        *)              error "Unsupported architecture: $(uname -m)" ;;
+    esac
+}
+
+# Determine install directory
+determine_install_dir() {
+    if [ -n "$INSTALL_DIR" ]; then
+        echo "$INSTALL_DIR"
+        return
+    fi
+
+    # Prefer /usr/local/bin if writable, otherwise ~/.local/bin
+    if [ -w "/usr/local/bin" ]; then
+        echo "/usr/local/bin"
+    else
+        echo "${HOME}/.local/bin"
+    fi
+}
+
+# Fetch latest version from GitHub Releases
+fetch_latest_version() {
+    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    local version
+
+    if command -v curl >/dev/null 2>&1; then
+        version=$(curl -fsSL "$url" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+    elif command -v wget >/dev/null 2>&1; then
+        version=$(wget -qO- "$url" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+    else
+        error "curl or wget is required"
+    fi
+
+    if [ -z "$version" ]; then
+        error "Failed to fetch latest version from GitHub"
+    fi
+    echo "$version"
+}
+
+# Download a file
+download() {
+    local url="$1" dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$url"
+    fi
+}
+
+main() {
+    printf "\n${CYAN}Watchfire Installer${NC}\n\n"
+
+    local os arch version install_dir
+    os=$(detect_os)
+    arch=$(detect_arch)
+    version=$(fetch_latest_version)
+    install_dir=$(determine_install_dir)
+
+    info "OS: $os | Arch: $arch | Version: v$version"
+    info "Install directory: $install_dir"
+
+    # Create install dir if needed
+    mkdir -p "$install_dir"
+
+    local base_url="https://github.com/${REPO}/releases/download/v${version}"
+    local cli_name="watchfire-${os}-${arch}"
+    local daemon_name="watchfired-${os}-${arch}"
+
+    # Download binaries
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    info "Downloading watchfire v${version}..."
+    download "${base_url}/${cli_name}" "${tmp_dir}/watchfire"
+    download "${base_url}/${daemon_name}" "${tmp_dir}/watchfired"
+
+    chmod +x "${tmp_dir}/watchfire" "${tmp_dir}/watchfired"
+
+    # Install
+    info "Installing to ${install_dir}..."
+    if [ -w "$install_dir" ]; then
+        mv "${tmp_dir}/watchfire" "${install_dir}/watchfire"
+        mv "${tmp_dir}/watchfired" "${install_dir}/watchfired"
+    else
+        warn "Elevated permissions required for ${install_dir}"
+        sudo mv "${tmp_dir}/watchfire" "${install_dir}/watchfire"
+        sudo mv "${tmp_dir}/watchfired" "${install_dir}/watchfired"
+    fi
+
+    # macOS: remove quarantine and ad-hoc sign
+    if [ "$os" = "darwin" ]; then
+        xattr -dr com.apple.quarantine "${install_dir}/watchfire" 2>/dev/null || true
+        xattr -dr com.apple.quarantine "${install_dir}/watchfired" 2>/dev/null || true
+        codesign --sign - --force "${install_dir}/watchfire" 2>/dev/null || true
+        codesign --sign - --force "${install_dir}/watchfired" 2>/dev/null || true
+    fi
+
+    # Verify
+    if "${install_dir}/watchfire" version >/dev/null 2>&1; then
+        ok "watchfire v${version} installed successfully!"
+    else
+        error "Installation failed — binary not executable"
+    fi
+
+    # Check if install dir is in PATH
+    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$install_dir"; then
+        printf "\n"
+        warn "${install_dir} is not in your PATH."
+        echo "  Add it by running:"
+        echo ""
+        if [ -f "${HOME}/.zshrc" ]; then
+            echo "    echo 'export PATH=\"${install_dir}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+        else
+            echo "    echo 'export PATH=\"${install_dir}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+        fi
+        echo ""
+    fi
+
+    printf "\n${GREEN}Get started:${NC}\n"
+    echo "  cd your-project"
+    echo "  watchfire init"
+    echo "  watchfire run"
+    printf "\n"
+}
+
+main "$@"

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "codename": "Ember"
 }


### PR DESCRIPTION
## Summary
- Add Linux + Windows build verification to CI
- Add Linux + Windows binary builds to release workflow
- Add install scripts (`install.sh`, `install.ps1`)
- Add no-CGO tray fallback for headless builds
- Update README with all-platform install docs

## Test plan
- [ ] CI: go-build-linux job passes
- [ ] CI: go-build-windows job passes
- [ ] CI: existing macOS jobs still pass
- [ ] CI: proto-lint, go-lint, go-test still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)